### PR TITLE
Restart program when provider schema changed

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -252,6 +252,9 @@ public class HoodieDeltaStreamer implements Serializable {
         + "https://spark.apache.org/docs/latest/job-scheduling.html")
     public Integer compactSchedulingMinShare = 0;
 
+    @Parameter(names = {"--check-provider-schema-change"}, description = "Check for provider schema change")
+    public Boolean checkProviderSchemaChange = false;
+
     /**
      * Compaction is enabled for MoR table by default. This flag disables it
      */
@@ -276,6 +279,10 @@ public class HoodieDeltaStreamer implements Serializable {
     public boolean isInlineCompactionEnabled() {
       return !continuousMode && !forceDisableCompaction
           && HoodieTableType.MERGE_ON_READ.equals(HoodieTableType.valueOf(tableType));
+    }
+
+    public boolean providerSchemaChangeEnabled() {
+      return continuousMode && checkProviderSchemaChange;
     }
   }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/S3FilebasedSchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/S3FilebasedSchemaProvider.java
@@ -31,6 +31,7 @@ import org.apache.log4j.Logger;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.hudi.common.util.TypedProperties;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.spark.api.java.JavaSparkContext;
 
@@ -87,17 +88,18 @@ public class S3FilebasedSchemaProvider extends SchemaProvider {
   }
 
   @Override
-  public Schema getLatestSourceSchema() {
+  public Pair<Schema, Boolean> getLatestSourceSchema() {
     long currentTimestamp = getTimestamp(new Date());
+    boolean schemaChanged = false;
     if (currentTimestamp - schemaCachedTS >= schemaExpiredTime) {
       LOG.info("Fetching the latest schema......");
       try {
-        fetchSchemaFromS3();
+        schemaChanged = fetchSchemaFromS3();
       } catch (IOException ioe) {
         LOG.error("Got errors while fetching the new schema", ioe);
       }
     }
-    return sourceSchema;
+    return Pair.of(sourceSchema, schemaChanged);
   }
 
   /**
@@ -113,10 +115,12 @@ public class S3FilebasedSchemaProvider extends SchemaProvider {
 
   /**
    * Read Avro Schema from S3.
+   * Return true if latest schema is fetched, and false if the schema has not changed.
    */
-  private void fetchSchemaFromS3() throws IOException {
+  private boolean fetchSchemaFromS3() throws IOException {
     S3Object s3Object = s3Client.getObject(getSchemaRequest());
     InputStream stream = s3Object.getObjectContent();
+    boolean schemaChanged = false;
     try {
       long fileTS = getTimestamp(s3Object.getObjectMetadata().getLastModified());
       if (sourceSchema == null || fileTS == 0 || lastModifiedTS != fileTS) {
@@ -126,8 +130,10 @@ public class S3FilebasedSchemaProvider extends SchemaProvider {
         }
         sourceSchema = schemaCache;
         lastModifiedTS = fileTS;
+        schemaChanged = true;
       }
       schemaCachedTS = getTimestamp(new Date());
+      return schemaChanged;
     } finally {
       readStream(stream);
       stream.close();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/schema/SchemaProvider.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.utilities.schema;
 
 import org.apache.hudi.common.util.TypedProperties;
+import org.apache.hudi.common.util.collection.Pair;
 
 import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -43,9 +44,11 @@ public abstract class SchemaProvider implements Serializable {
 
   /**
    * Refresh and get latest source schema.
+   * Return a pair whose first member is the latest schema, and second member is set to true
+   * if a new schema was fetched or false if the schema has not changed.
    */
-  public Schema getLatestSourceSchema() {
-    return getSourceSchema();
+  public Pair<Schema, Boolean> getLatestSourceSchema() {
+    return Pair.of(getSourceSchema(), false);
   }
 
   public Schema getTargetSchema() {


### PR DESCRIPTION
Context: HUDI-603

When provider schema changed, restart delta stream program to use the new schema.
We use this option for a couple of reasons:
1. Spark serialization of Avro record and schema is optimized when schemas are registered before program is executed, i.e. executors are spawned by the driver.
If we refresh schema w/o recreating SparkConf and executors, the serialization optimization would be defeated.
2. It is not frequent for table schema to be updated.
