### PR TITLE
Enhance Mongo convert to address extended Json

### DIFF
--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -139,6 +139,13 @@
       <artifactId>log4j</artifactId>
     </dependency>
 
+    <!-- MongoDB -->
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>bson</artifactId>
+      <version>3.12.1</version>
+    </dependency>
+
     <!-- Fasterxml -->
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaAvroConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaAvroConverter.java
@@ -31,6 +31,8 @@ public abstract class KafkaAvroConverter {
     } else {
       return StreamSupport
           .stream(Spliterators.spliteratorUnknownSize(records, Spliterator.ORDERED), false)
+          // Ignore tombstone record
+          .filter((r) -> r.value() != null)
           .map((r) -> transform((String)r.key(), (String)r.value())).iterator();
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMongoAvroConverter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestMongoAvroConverter.java
@@ -13,11 +13,12 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TestMongoAvroConverter {
 
   @Test
-  public void testReadKey() throws IOException {
+  public void testDocumentId() throws IOException {
     Schema.Parser parser = new Schema.Parser();
     Path sampleSchemaPath = Paths.get("src/test/resources/unitTest/TestMongoAvroConverterSampleSchema.avsc");
     String sampleSchemaStr = new String(Files.readAllBytes(sampleSchemaPath));
@@ -26,7 +27,7 @@ public class TestMongoAvroConverter {
     Schema schema = parser.parse(sampleSchemaStr);
     MongoAvroConverter transformer = new MongoAvroConverter(schema);
     String createSampleId = "55555505d648da1824d45a1d";
-    assertEquals(createSampleId, transformer.readKey(sampleKeyStr));
+    assertEquals(createSampleId, transformer.getDocumentId(sampleKeyStr));
   }
 
   @Test
@@ -48,7 +49,7 @@ public class TestMongoAvroConverter {
 
     String updateSampleId = "55555505d648da1824d45a1d";
     String updateSampleOp = "u";
-    Long updateSampleTsMs = 1587506573735L;
+    Long updateSampleTsMs = 1587409166000L;
     String updateSamplePatch = "{\"$v\": 1,\"$set\": {\"e\": false,\"l\": {\"$date\":1587409165984}}}";
 
     assertEquals(updateSampleId, resultUpdate.get("_id"));
@@ -58,8 +59,7 @@ public class TestMongoAvroConverter {
 
     String createSampleId = "55555505d648da1824d45a1d";
     String createSampleOp = "c";
-    Long createSampleTsMs = 1587506600617L;
-    String createSamplePatch = "null";
+    Long createSampleTsMs = 1587403470000L;
     String createSampleIpc = "USD";
     Boolean createSampleLfd = false;
     Boolean createSampleCb = false;
@@ -71,7 +71,7 @@ public class TestMongoAvroConverter {
     assertEquals(createSampleId, resultCreate.get("_id"));
     assertEquals(createSampleOp, resultCreate.get("_op"));
     assertEquals(createSampleTsMs, resultCreate.get("_ts_ms"));
-    assertEquals(createSamplePatch, resultCreate.get("_patch"));
+    assertNull(resultCreate.get("_patch"));
     assertEquals(createSampleIpc, resultCreate.get("incentive_payment_currency"));
     assertEquals(createSampleLfd, resultCreate.get("logistic_fee_deducted"));
     assertEquals(createSampleCb, resultCreate.get("chargeback"));

--- a/hudi-utilities/src/test/resources/unitTest/TestMongoAvroConverterSampleSchema.avsc
+++ b/hudi-utilities/src/test/resources/unitTest/TestMongoAvroConverterSampleSchema.avsc
@@ -463,7 +463,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+            "type": "array",
+            "items": "string"
+        }
       ],
       "name":"escrow_payment_ids",
       "aliases":[
@@ -474,7 +477,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+            "type": "array",
+            "items": "float"
+        }
       ],
       "name":"escrow_payment_amounts",
       "aliases":[
@@ -485,7 +491,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+            "type": "array",
+            "items": "float"
+        }
       ],
       "name":"escrow_payment_tax_amounts",
       "aliases":[
@@ -496,7 +505,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+            "type": "array",
+            "items": "long"
+        }
       ],
       "name":"escrow_payment_time",
       "aliases":[
@@ -870,7 +882,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+            "type": "array",
+            "items": "string"
+        }
       ],
       "name":"refund_items",
       "aliases":[
@@ -1310,7 +1325,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+          "type":"array",
+          "items":"string"
+        }
       ],
       "name":"policy_fine_ids",
       "aliases":[
@@ -1640,7 +1658,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+          "type":"array",
+          "items":"string"
+        }
       ],
       "name":"lot_info",
       "aliases":[
@@ -1651,7 +1672,10 @@
       "default":null,
       "type":[
         "null",
-        "string"
+        {
+          "type":"array",
+          "items":"string"
+        }
       ],
       "name":"rebates",
       "aliases":[


### PR DESCRIPTION
Enhance Mongo converter to use Bson* class for handling extended Json format.
The supported conversion is outlined in the typeTransform function, we can add more if needed in the future.

It also handle legitimate case for OpLog not having payload or schema field.

I had to address incorrect schema types, according to the model Python file.
