### PR TITLE
Add schema parameter to preCombine API

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/common/TestRawTripPayload.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/TestRawTripPayload.java
@@ -82,7 +82,7 @@ public class TestRawTripPayload implements HoodieRecordPayload<TestRawTripPayloa
   }
 
   @Override
-  public TestRawTripPayload preCombine(TestRawTripPayload another) {
+  public TestRawTripPayload preCombine(TestRawTripPayload another, Schema schema) {
     return another;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java
@@ -50,7 +50,7 @@ public class HoodieJsonPayload implements HoodieRecordPayload<HoodieJsonPayload>
   }
 
   @Override
-  public HoodieJsonPayload preCombine(HoodieJsonPayload another) {
+  public HoodieJsonPayload preCombine(HoodieJsonPayload another, Schema schema) {
     return this;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EmptyHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EmptyHoodieRecordPayload.java
@@ -36,7 +36,7 @@ public class EmptyHoodieRecordPayload implements HoodieRecordPayload<EmptyHoodie
   }
 
   @Override
-  public EmptyHoodieRecordPayload preCombine(EmptyHoodieRecordPayload another) {
+  public EmptyHoodieRecordPayload preCombine(EmptyHoodieRecordPayload another, Schema schema) {
     return another;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroPayload.java
@@ -51,7 +51,7 @@ public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload>
   }
 
   @Override
-  public HoodieAvroPayload preCombine(HoodieAvroPayload another) {
+  public HoodieAvroPayload preCombine(HoodieAvroPayload another, Schema schema) {
     return this;
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
@@ -37,7 +37,7 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
    * When more than one HoodieRecord have the same HoodieKey, this function combines them before attempting to
    * insert/upsert (if combining turned on in HoodieClientConfig).
    */
-  T preCombine(T another);
+  T preCombine(T another, Schema schema);
 
   /**
    * This methods lets you write custom merging/combining logic to produce new values as a function of current value on

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -48,7 +48,8 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   @Override
-  public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload another) {
+  public OverwriteWithLatestAvroPayload preCombine(OverwriteWithLatestAvroPayload another,
+      Schema schema) {
     // pick the payload with greatest ordering value
     if (another.orderingVal.compareTo(orderingVal) > 0) {
       return another;

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -111,7 +111,8 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
     if (records.containsKey(key)) {
       // Merge and store the merged record. The HoodieRecordPayload implementation is free to decide what should be
       // done when a delete (empty payload) is encountered before or after an insert/update.
-      HoodieRecordPayload combinedValue = hoodieRecord.getData().preCombine(records.get(key).getData());
+      HoodieRecordPayload combinedValue = hoodieRecord.getData().preCombine(
+          records.get(key).getData(), readerSchema);
       records.put(key, new HoodieRecord<>(new HoodieKey(key, hoodieRecord.getPartitionPath()), combinedValue));
     } else {
       // Put the record as is

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/AvroBinaryTestPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/AvroBinaryTestPayload.java
@@ -49,7 +49,7 @@ public class AvroBinaryTestPayload implements HoodieRecordPayload {
   }
 
   @Override
-  public HoodieRecordPayload preCombine(HoodieRecordPayload another) {
+  public HoodieRecordPayload preCombine(HoodieRecordPayload another, Schema schema) {
     return this;
   }
 

--- a/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
+++ b/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
@@ -298,12 +298,12 @@ class TestDataSourceDefaults extends AssertionsForJUnit {
     val overWritePayload2 = new OverwriteWithLatestAvroPayload(laterRecord, 2)
 
     // it will provide the record with greatest combine value
-    val combinedPayload12 = overWritePayload1.preCombine(overWritePayload2)
+    val combinedPayload12 = overWritePayload1.preCombine(overWritePayload2, schema)
     val combinedGR12 = combinedPayload12.getInsertValue(schema).get().asInstanceOf[GenericRecord]
     assertEquals("field2", combinedGR12.get("field1").toString)
 
     // and it will be deterministic, to order of processing.
-    val combinedPayload21 = overWritePayload2.preCombine(overWritePayload1)
+    val combinedPayload21 = overWritePayload2.preCombine(overWritePayload1, schema)
     val combinedGR21 = combinedPayload21.getInsertValue(schema).get().asInstanceOf[GenericRecord]
     assertEquals("field2", combinedGR21.get("field1").toString)
   }
@@ -315,7 +315,7 @@ class TestDataSourceDefaults extends AssertionsForJUnit {
     val emptyPayload2 = new EmptyHoodieRecordPayload(laterRecord, 2)
 
     // it will provide an empty record
-    val combinedPayload12 = emptyPayload1.preCombine(emptyPayload2)
+    val combinedPayload12 = emptyPayload1.preCombine(emptyPayload2, schema)
     val combined12 = combinedPayload12.getInsertValue(schema)
     assertEquals(Option.empty(), combined12)
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HUDI-898 

There are 4 Mongo OpLog operations we need to handle, CRUD (create, read, update, delete).

Currently Hudi handle create/read, delete, but not update well with existing preCombine API in HoodieRecordPayload class. In particularly, Update operation contains "patch" field, which is extended Json describing update for dot separated field paths.

We need to pass Avro schema to preCombine API for it to work:
Even though BaseAvroPayload constructor accepts GenericRecord, which has Avro schema reference, but it materialize GenericRecord to bytes, to support serialization/deserialization by ExternalSpillableMap.