### PR TITLE
Use schema string instead of structType

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/mongo/SchemaUtils.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/mongo/SchemaUtils.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.log4j.LogManager;
@@ -40,17 +41,18 @@ public class SchemaUtils {
   public static final String OP_FIELD = "_op";
   public static final String TS_MS_FIELD = "_ts_ms";
   public static final String PATCH_FIELD = "_patch";
-  public static final String[] OPLOG_FIELD_NAMES = new String[]{
-      ID_FIELD, OP_FIELD, TS_MS_FIELD, PATCH_FIELD
-  };
-  public static final Type[] OPLOG_FIELD_TYPES = new Type[]{
-      Type.STRING, Type.STRING, Type.LONG, Type.STRING
-  };
   private static final Logger LOG = LogManager.getLogger(SchemaUtils.class);
 
   @SuppressWarnings("deprecation") // Backward compatible with Mongo libraries
   public static final JsonWriterSettings STRICT_JSON = JsonWriterSettings.builder()
       .outputMode(JsonMode.STRICT).build();
+
+  public static Schema buildOplogBaseSchema() {
+    SchemaBuilder.FieldAssembler<Schema> fieldAssembler = SchemaBuilder
+        .record("MongoOplog").namespace("com.wish.log").fields();
+    return fieldAssembler.optionalString(ID_FIELD).optionalString(OP_FIELD)
+        .optionalLong(TS_MS_FIELD).optionalString(PATCH_FIELD).endRecord();
+  }
 
   /**
    * Extract fields from json value to generic record.

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaAvroConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/KafkaAvroConverter.java
@@ -1,6 +1,5 @@
 package org.apache.hudi.utilities.sources.helpers;
 
-import org.apache.hudi.AvroConversionUtils;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
@@ -10,38 +9,33 @@ import java.util.stream.StreamSupport;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.spark.sql.types.StructType;
 
 /**
  * Convert a list of Kafka ConsumerRecord<String, String> to GenericRecord.
  */
 public abstract class KafkaAvroConverter implements Serializable {
-  // Use GenericRecord as schema wrapper to leverage Spark Kyro serialization.
-  
-  private final StructType avroSchema;
-  private final String structName;
+  private final String schemaStr;
 
-  public KafkaAvroConverter(StructType schema, String name) {
-    avroSchema = schema;
-    structName = name;
+  public KafkaAvroConverter(String schemaStr) {
+    this.schemaStr = schemaStr;
   }
 
-  public Schema getSchema() {
-    return AvroConversionUtils.convertStructTypeToAvroSchema(avroSchema, structName,
-        "hudi." + structName);
+  private Schema getSchema() {
+    return new Schema.Parser().parse(schemaStr);
   }
 
   public Iterator<GenericRecord> apply(Iterator<ConsumerRecord<Object, Object>> records) {
     if (!records.hasNext()) {
       return Collections.emptyIterator();
     } else {
+      final Schema schema = getSchema();
       return StreamSupport
           .stream(Spliterators.spliteratorUnknownSize(records, Spliterator.ORDERED), false)
           // Ignore tombstone record
           .filter((r) -> r.value() != null)
-          .map((r) -> transform((String)r.key(), (String)r.value())).iterator();
+          .map((r) -> transform(schema, (String) r.key(), (String) r.value())).iterator();
     }
   }
 
-  protected abstract GenericRecord transform(String key, String value);
+  protected abstract GenericRecord transform(Schema schema, String key, String value);
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/MongoAvroConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/MongoAvroConverter.java
@@ -1,5 +1,6 @@
 package org.apache.hudi.utilities.sources.helpers;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.utilities.mongo.Operation;
@@ -10,7 +11,6 @@ import org.bson.codecs.BsonObjectIdCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.json.JsonReader;
 import org.json.JSONObject;
-import org.apache.spark.sql.types.StructType;
 
 public class MongoAvroConverter extends KafkaAvroConverter {
 
@@ -23,13 +23,13 @@ public class MongoAvroConverter extends KafkaAvroConverter {
   private static final String PAYLOAD_OPLOGFIELD = "payload";
   private static final String SOURCE_OPLOGFIELD = "source";
 
-  public MongoAvroConverter(StructType avroSchema, String name) {
-    super(avroSchema, name);
+  public MongoAvroConverter(String schemaStr) {
+    super(schemaStr);
   }
 
   @Override
-  public GenericRecord transform(String key, String value) {
-    GenericRecord genericRecord = new Record(this.getSchema());
+  public GenericRecord transform(Schema schema, String key, String value) {
+    GenericRecord genericRecord = new Record(schema);
     genericRecord.put(SchemaUtils.ID_FIELD, getDocumentId(key));
 
     // Payload field may be absent when value.converter.schemas.enable=false
@@ -59,7 +59,7 @@ public class MongoAvroConverter extends KafkaAvroConverter {
     return genericRecord;
   }
 
-  private static long getTimeMs(JSONObject valueJson) {
+  private static Long getTimeMs(JSONObject valueJson) {
     // Source field is mandatory
     JSONObject source = valueJson.getJSONObject(SOURCE_OPLOGFIELD);
     long timeMs = source.optLong(TS_MS_OPLOGFIELD);

--- a/hudi-utilities/src/test/resources/unitTest/TestMongoAvroConverterSampleSchema.avsc
+++ b/hudi-utilities/src/test/resources/unitTest/TestMongoAvroConverterSampleSchema.avsc
@@ -3,16 +3,28 @@
   "name":"MongoOplog",
   "fields":[
     {
-      "name":"_op",
-      "type":"string"
+      "default":null,
+      "type":[
+        "null",
+        "string"
+      ],
+      "name":"_id"
     },
     {
-      "name":"_ts_ms",
+      "default":null,
+      "type":[
+        "null",
+        "string"
+      ],
+      "name":"_op"
+    },
+    {
+      "default":null,
       "type":[
         "null",
         "long"
       ],
-      "default":null
+      "name":"_ts_ms"
     },
     {
       "name":"_patch",
@@ -21,14 +33,6 @@
         "string"
       ],
       "default":null
-    },
-    {
-      "default":null,
-      "type":[
-        "null",
-        "string"
-      ],
-      "name":"_id"
     },
     {
       "default":null,


### PR DESCRIPTION
Pass schema json string instead of converting to structType and back to Schema, as the later does not preserve original schema.

Alternative considered:
I experimented with augmenting spark utility SchemaConverters, by preserving field aliases thru org.apache.spark.sql.types.Metadata, and flipping NULL in the union representing nullable schema.
It worked for Mongo usage case. However, I noticed Hudi code base uses SchemaConverters in several places,
where Hudi write schema defined some fields as union of [NULL, string|long] while others as union of [integer, NULL]. The  SchemaConverters cannot preserve the order of NULL in unions, without being updated which would impact SchemaType case class. We should work with Spark community to properly address it in a generic way.