### PR TITLE
fix parsing logic when mongo doc _id is not ObjectId

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/MongoAvroConverter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/helpers/MongoAvroConverter.java
@@ -6,6 +6,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.utilities.mongo.Operation;
 import org.apache.hudi.utilities.mongo.SchemaUtils;
 import org.bson.BsonDocument;
+import org.bson.BsonInvalidOperationException;
 import org.bson.BsonObjectId;
 import org.bson.codecs.BsonObjectIdCodec;
 import org.bson.codecs.DecoderContext;
@@ -79,6 +80,11 @@ public class MongoAvroConverter extends KafkaAvroConverter {
     if (keyJson.has(PAYLOAD_OPLOGFIELD)) {
       keyJson = keyJson.getJSONObject(PAYLOAD_OPLOGFIELD);
     }
-    return getObjectId(keyJson.getString(ID_OPLOGFIELD)).getValue().toString();
+    try {
+      return getObjectId(keyJson.getString(ID_OPLOGFIELD)).getValue().toString();
+    }
+    catch (BsonInvalidOperationException ex){
+      return keyJson.getString(ID_OPLOGFIELD);
+    }
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.